### PR TITLE
Don't install phpenv

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -29,7 +29,6 @@ brew "rbenv"
 # WordPress stuff
 tap "dxw/tap"
 brew "composer"
-brew "phpenv"
 brew "dxw/tap/whippet"
 
 # Scripting stuff


### PR DESCRIPTION
Homebrew doesn't have it and it's dead anyway.

Fixes #7 