### PR TITLE
Rewrite code that appends to /etc/shells to not use redirection with sudo

### DIFF
--- a/install
+++ b/install
@@ -90,7 +90,8 @@ pause
 say-loud "Setting ZSH as the default shell"
 say "You might be asked for your login password..."
 # shellcheck disable=SC2016
-run 'sudo echo "$(brew --prefix)/bin/zsh" >> /etc/shells'
+run 'echo "$(brew --prefix)/bin/zsh" | sudo tee -a /etc/shells'
+
 # shellcheck disable=SC2016
 run 'chsh -s "$(brew --prefix)/bin/zsh" "$USER"'
 


### PR DESCRIPTION
Should fix https://github.com/dxw/local-env/issues/10

https://askubuntu.com/questions/103643/cannot-echo-hello-x-txt-even-with-sudo
says redirection is higher-priority than running commands so `sudo ... >> file` can't work with protected files, and
suggests (paraphrased)

sudo bash -c 'echo "$(brew --prefix)/bin/zsh" >> /etc/shells'