### PR TITLE
on Mac sed -i expects a parameter afterwards: added

### DIFF
--- a/install
+++ b/install
@@ -120,8 +120,8 @@ else
 fi
 
 if ! ask_Yn "Are you content with using nano as your 'EDITOR'?"; then
-  ask "What should we set 'EDITOR' to?"
-  sed -i s/export EDITOR=nano/export EDITOR=\""$REPLY"\"/ ~/.zshrc
+  ask "What should we set 'EDITOR' to? [command name only, not a path]"
+  sed -i '' 's/export EDITOR=nano/export EDITOR="'"$REPLY"'"/' ~/.zshrc
   instruct "You might want to check '$REPLY' is installed after we're done."
 fi
 


### PR DESCRIPTION
Apparently the default sed on Mac is different, expecting a parameter for where to back the old file up to.

https://stackoverflow.com/questions/19456518/error-when-using-sed-with-find-command-on-os-x-invalid-command-code/19457213#19457213

Apparently this argument is the extension of what the old file gets backed up to. (This currently doesn't make a backup of the original file.)

The suggestion to instead install gnu sed via`brew install gnu-sed` is also worth consideration.