### PR TITLE
Ensure VS Code doesn't return empty commit message

### DIFF
--- a/src/zshrc
+++ b/src/zshrc
@@ -172,8 +172,4 @@ bindkey '^[[B' history-substring-search-down
 
 export EDITOR=nano
 
-if command -v code >/dev/null 2>&1; then
-  export VISUAL=code
-fi
-
 # END local-env


### PR DESCRIPTION
If `VISUAL` is set to `code` it will return an empty commit message. `code --wait` does not.

Personally I find the idea of the commit message not being where I typed `git commit` unhelpful, so I've set mine to `vim` and haven't tested this in the installer, only at the command line.