### PR TITLE
Make brew bundle install command to be verbose

### DIFF
--- a/install
+++ b/install
@@ -80,7 +80,7 @@ pause
 say-loud "Installing recommended packages and apps with Homebrew"
 say "You might be asked for your login password"
 say "This might take a while..."
-run 'brew bundle install --no-lock'
+run 'brew bundle install --no-lock --verbose'
 pause
 
 # End dependencies via Homebrew


### PR DESCRIPTION
When the `brew bundle install` command is run, it is now more verbose, providing more details of the installation.