### PR TITLE
Use alternative to deprecated flag

### DIFF
--- a/src/zshrc
+++ b/src/zshrc
@@ -68,7 +68,7 @@ compinit
 
 if command -v ssh-agent >/dev/null 2>&1; then
   eval "$(ssh-agent)"
-  ssh-add -A
+  ssh-add --apple-load-keychain
 fi
 
 # zgen settings


### PR DESCRIPTION
When upgrading to MacOS 12 Monterey, the following warning appeared
at the start of each shell:

WARNING: The -K and -A flags are deprecated and have been replaced
         by the --apple-use-keychain and --apple-load-keychain
         flags, respectively.  To suppress this warning, set the
         environment variable APPLE_SSH_ADD_BEHAVIOR as described in
         the ssh-add(1) manual page.