### PR TITLE
Allow continuing after a failed brew install

### DIFF
--- a/install
+++ b/install
@@ -80,7 +80,7 @@ pause
 say-loud "Installing recommended packages and apps with Homebrew"
 say "You might be asked for your login password"
 say "This might take a while..."
-run 'brew bundle install --no-lock --verbose'
+run_with_retry 'brew bundle install --no-lock --verbose'
 pause
 
 # End dependencies via Homebrew

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 
+source lib/print.sh
+
 run() {
   echo -e "\x1B[1;34m==\$ $*\x1B[0m"
   eval "$*"
+}
+
+run_with_retry() {
+  if ! run "$*"; then
+    say "It looks like the last step didn't finish completely."
+    say "You can either try running it again or continue as is."
+    say "It's unlikely to cause any major issues if you continue."
+
+    if ask_Yn "Retry the last step?"; then
+      run_with_retry "$*"
+    fi
+  fi
 }


### PR DESCRIPTION
If you have manually installed some apps, Homebrew will fail to install them again, causing the script to fail and setup to be left incomplete.

Fixes #23
Closes #24