### PR TITLE
Add zsh configuration for adr-tools

### DIFF
--- a/src/zshrc
+++ b/src/zshrc
@@ -170,6 +170,11 @@ bindkey -M menuselect '^o' accept-and-infer-next-history
 bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
 
+# Use the provided Bash autocompletion for adr-tools. Note that there are other
+# scripts in this directory, but not all of them work well with zsh.
+autoload -U +X bashcompinit && bashcompinit
+source $(brew --prefix)/etc/bash_completion.d/adr-tools
+
 export EDITOR=nano
 
 # END local-env


### PR DESCRIPTION
Resolves #29 

This  PR adds two pieces of configuration to the zsh config:

1. Autocomplete scripts for `adr-tools`.
2. A setting for `$VISUAL`, which is identical to `$EDITOR`.

`$VISUAL` is not strictly necessary in modern shells, but Git, `adr-tools`, and other programs will give `$VISUAL` preference over `$EDITOR`, and some developers will prefer to different editors for different tasks. This is explained in an inline comment.