### PR TITLE
Remove zsh configuration for phpenv

### DIFF
--- a/src/zshrc
+++ b/src/zshrc
@@ -137,10 +137,6 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
-if command -v phpenv >/dev/null 2>&1; then
-  eval "$(phpenv init -)"
-fi
-
 alias -g ...='../..'
 alias -g ....='../../..'
 alias -g .....='../../../..'


### PR DESCRIPTION
`phpenv` is not in the approved software list, and was removed from the list of Homebrew apps to install in commit 05ee8be3dc1b868485db293bab96ce4c3868fd06