### PR TITLE
Feature/govpress dev needs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,9 +26,15 @@ cask "docker"
 # Ruby stuff
 brew "rbenv"
 
+# PHP stuff
+brew "php@7.4"
+brew "php@8.0"
+brew "php@8.1"
+brew "php-version"
+brew "composer"
+
 # WordPress stuff
 tap "dxw/tap"
-brew "composer"
 brew "dxw/tap/whippet"
 
 # Scripting stuff

--- a/src/zshrc
+++ b/src/zshrc
@@ -174,7 +174,8 @@ bindkey '^[[B' history-substring-search-down
 # Use the provided Bash autocompletion for adr-tools. Note that there are other
 # scripts in this directory, but not all of them work well with zsh.
 autoload -U +X bashcompinit && bashcompinit
-source $(brew --prefix)/etc/bash_completion.d/adr-tools
+# shellcheck source=/dev/null
+source "$(brew --prefix)/etc/bash_completion.d/adr-tools"
 
 export EDITOR=nano
 

--- a/src/zshrc
+++ b/src/zshrc
@@ -137,6 +137,11 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
+if [[ -f "$(brew --prefix php-version)/php-version.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$(brew --prefix php-version)/php-version.sh" && php-version 7.4
+fi
+
 alias -g ...='../..'
 alias -g ....='../../..'
 alias -g .....='../../../..'


### PR DESCRIPTION
* PHP LTS versions
* `php-version` with configuration

This PR also tidies up a previous commit which was raising a ShellCheck error.