### PR TITLE
Remove deprecated or now-redundant Homebrew taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,10 +1,5 @@
 # Homebrew stuff
 tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/cask-drivers"
-tap "homebrew/cask-fonts"
-tap "homebrew/cask-versions"
-tap "homebrew/core"
 tap "homebrew/services"
 brew "mas"
 
@@ -75,7 +70,6 @@ cask "google-chrome"
 cask "microsoft-edge"
 
 # Terminal stuff
-tap "homebrew/cask-fonts"
 brew "direnv"
 brew "starship"
 cask "font-fira-code-nerd-font"


### PR DESCRIPTION
Per https://github.com/dxw/local-env/issues/37, these taps are either deprecated or no longer necessary

The casks contained in https://github.com/Homebrew/homebrew-cask-drivers, https://github.com/Homebrew/homebrew-cask-fonts, and https://github.com/Homebrew/homebrew-cask-versions have all been migrated to https://github.com/Homebrew/homebrew-cask, which is accessible in a fresh Homebrew install with no extra steps

The homebrew/cask and homebrew/core taps are also now accessible by default, so they don't need including in a Brewfile

Thanks to @william-man for flagging!